### PR TITLE
[Hotfix] Version 0.3.2 - Fix validation logic for complex expressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.3.1"
+version = "0.3.2"
 description = "Educational MCP server demonstrating FastMCP 2.0 best practices - Complete learning guide with contributing guidelines and roadmap for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/math_mcp/server.py
+++ b/src/math_mcp/server.py
@@ -92,13 +92,12 @@ def _validate_expression_syntax(expression: str) -> None:
     if "pow(" in clean_expr and "," not in clean_expr:
         raise ValueError("Function 'pow()' requires two parameters: pow(base, exponent). Example: pow(2, 3)")
 
-    # Check for missing parameters in other functions
+    # Check for empty function calls (functions with no parameters)
     single_param_funcs = ["sin", "cos", "tan", "log", "sqrt", "abs"]
     for func in single_param_funcs:
-        if f"{func}(" in clean_expr:
-            # Basic check for opening but no closing parenthesis
-            if clean_expr.count(f"{func}(") != clean_expr.count(")"):
-                raise ValueError(f"Function '{func}()' requires one parameter. Example: {func}(3.14)")
+        empty_call = f"{func}()"
+        if empty_call in clean_expr:
+            raise ValueError(f"Function '{func}()' requires one parameter. Example: {func}(3.14)")
 
 def safe_eval_expression(expression: str) -> float:
     """Safely evaluate mathematical expressions with restricted scope."""


### PR DESCRIPTION
## Critical Hotfix for v0.3.1 Validation Issue

### 🐛 Issue Fixed
Version 0.3.1 introduced overly strict validation logic that incorrectly rejected valid complex mathematical expressions like:
- ❌ `sqrt(16) + pow(2, 3)` (was failing)
- ❌ `sin(3.14159/2) + cos(0)` (was failing)

### ✅ Solution
- **Root Cause**: Flawed parentheses counting logic that counted ALL parentheses in complex expressions
- **Fix**: Simplified validation to only check for empty function calls (e.g., `sqrt()`, `sin()`)
- **Result**: Complex expressions now work correctly while maintaining helpful error messages

### 🧪 Testing Results
**Working Correctly:**
- ✅ `pow(2, 3)` = 8.0
- ✅ `sqrt(16)` = 4.0
- ✅ `sqrt(16) + pow(2, 3)` = 12.0
- ✅ `sin(3.14159/2) + cos(0)` ≈ 2.0

**Proper Error Handling:**
- ❌ `pow(2)` → "Function 'pow()' requires two parameters: pow(base, exponent). Example: pow(2, 3)"
- ❌ `sqrt()` → "Function 'sqrt()' requires one parameter. Example: sqrt(3.14)"
- ❌ `sin() + cos(1)` → "Function 'sin()' requires one parameter. Example: sin(3.14)"

### 📦 Version Update
- Version bumped to 0.3.2 for hotfix release
- Maintains all FastMCP 2.0 compliance and security features
- Backward compatible with all existing functionality

**Critical fix - ready for immediate merge and release.**