### PR TITLE
[Fix] Update workflow to install dev dependencies for tests

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,7 +23,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --all-extras
 
       - name: Run test suite
         run: uv run python -m pytest tests/ -v


### PR DESCRIPTION
## Summary
Fixes GitHub Actions workflow to install dev dependencies required for running tests.

## Problem
The workflow was failing because pytest wasn't installed. The `uv sync` command only installs production dependencies by default.

## Solution
Changed `uv sync` to `uv sync --all-extras` to install all optional dependencies including:
- dev extras (pytest, mypy, ruff)
- plotting extras (matplotlib, numpy)

## Testing
This fix will be validated when the workflow runs again after the v0.6.0 release is recreated.

## Impact
- Fixes CI/CD pipeline test execution
- Enables automated PyPI publishing workflow
- No impact on local development