### PR TITLE
docs: Clarify MCP client requirements and standardize on uv for v0.6.5

### DIFF
--- a/FUTURE_IMPROVEMENTS.md
+++ b/FUTURE_IMPROVEMENTS.md
@@ -7,9 +7,19 @@ This document outlines the strategic evolution from a basic **math calculator MC
 This project follows **FastMCP 2.0 best practices**:
 - **Core dependencies**: Minimal in `[project.dependencies]` (fastmcp>=2.0.0, pydantic>=2.11.9)
 - **Optional features**: Defined in `[project.optional-dependencies]` for plotting, etc.
-- **Production**: Install via PyPI with optional groups: `pip install math-mcp-learning-server[plotting]`
+- **Production**: Install via PyPI with optional groups: `uv pip install math-mcp-learning-server[plotting]`
 - **Development**: `uv sync --all-extras` for all optional dependencies
 - **Cloud deployment**: Automatic via FastMCP Cloud (https://math-mcp-learning.fastmcp.app/mcp)
+
+## 🔌 **MCP Client Requirement**
+
+**This is an MCP server** - all features require an MCP-compatible client to use:
+- Claude Desktop, Claude Code
+- OpenCode, Amazon Q
+- Codex CLI, Gemini CLI
+- Any other MCP-compatible client
+
+**Cannot run standalone** - must be connected through an MCP client for testing and usage.
 
 ## 🎯 **Strategic Vision: Beyond Claude's Native Capabilities**
 
@@ -61,9 +71,9 @@ def load_variable(name: str) -> dict:
     # Access saved values across Claude sessions
 ```
 
-**User Experience:**
+**User Experience (via MCP Client):**
 ```bash
-# Session 1 with Claude
+# Session 1 - Using Claude Desktop/Code or other MCP client
 save_calculation("portfolio_return", "10000 * 1.07^5", 14025.52)
 
 # Session 2 (next day) - Claude remembers nothing, MCP remembers everything
@@ -114,11 +124,13 @@ def plot_financial_chart(data: dict, chart_type: str) -> dict:
 **Installation:**
 ```bash
 # Install from PyPI with plotting support:
-pip install math-mcp-learning-server[plotting]
+uv pip install math-mcp-learning-server[plotting]
 
 # Or install plotting dependencies separately:
-pip install math-mcp-learning-server
-pip install matplotlib numpy
+uv pip install math-mcp-learning-server
+uv pip install matplotlib numpy
+
+# Then connect via MCP client (Claude Desktop, Claude Code, etc.)
 ```
 
 **Educational Value:** Visual learning dramatically improves mathematical understanding
@@ -180,11 +192,13 @@ async def get_astronomical_data(query: str) -> dict:
 **Installation:**
 ```bash
 # Install data integration dependencies:
-pip install math-mcp-learning-server
-pip install httpx pandas
+uv pip install math-mcp-learning-server
+uv pip install httpx pandas
 
 # Or via extras (when data group is added):
-pip install math-mcp-learning-server[data]
+uv pip install math-mcp-learning-server[data]
+
+# Then connect via MCP client
 ```
 
 ### **Phase 4: High-Performance Computing (Advanced)**
@@ -210,11 +224,13 @@ def optimize_portfolio(returns: list, risks: list, constraints: dict) -> dict:
 **Installation:**
 ```bash
 # Install scientific computing dependencies:
-pip install math-mcp-learning-server[plotting]
-pip install numpy scipy pandas
+uv pip install math-mcp-learning-server[plotting]
+uv pip install numpy scipy pandas
 
 # Or via extras (when scientific group is added):
-pip install math-mcp-learning-server[scientific]
+uv pip install math-mcp-learning-server[scientific]
+
+# Then connect via MCP client
 ```
 
 ## 🏗️ **Technical Implementation Strategy**
@@ -248,28 +264,30 @@ def advanced_statistics(data: list[float]) -> dict:
     except ImportError:
         return {
             "error": "Advanced statistics requires scipy",
-            "install": "pip install math-mcp-learning-server[scientific]",
-            "note": "Or install scipy separately: pip install scipy"
+            "install": "uv pip install math-mcp-learning-server[scientific]",
+            "note": "Or install scipy separately: uv pip install scipy"
         }
 ```
 
 #### **✅ User Installation Commands**
 ```bash
 # Install from PyPI (basic):
-pip install math-mcp-learning-server
+uv pip install math-mcp-learning-server
 
 # Install with optional features:
-pip install math-mcp-learning-server[plotting]
-pip install math-mcp-learning-server[dev]
+uv pip install math-mcp-learning-server[plotting]
+uv pip install math-mcp-learning-server[dev]
 
 # Install all features:
-pip install math-mcp-learning-server[plotting,dev]
+uv pip install math-mcp-learning-server[plotting,dev]
 
 # Development (local):
 git clone https://github.com/huguesclouatre/math-mcp-learning-server
 cd math-mcp-learning-server
 uv sync --all-extras
 uv run fastmcp dev src/math_mcp/server.py
+
+# Then connect via MCP client (Claude Desktop, Claude Code, OpenCode, etc.)
 
 # Cloud deployment:
 # Visit https://math-mcp-learning.fastmcp.app/mcp

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Perfect for learning MCP fundamentals, demonstrating professional patterns, and 
 
 Built with [FastMCP 2.0](https://github.com/jlowin/fastmcp) and the official [Model Context Protocol Python SDK](https://github.com/modelcontextprotocol/python-sdk).
 
+## Requirements
+
+**This is an MCP server** - it requires an MCP client to use. Supported clients include:
+
+- **Claude Desktop** - Anthropic's desktop app with native MCP support
+- **Claude Code** - Command-line MCP client from Anthropic
+- **OpenCode** - Open-source MCP client
+- **Amazon Q** - AWS's AI assistant with MCP support
+- **Codex CLI** - GitHub Codex command-line interface
+- **Gemini CLI** - Google's Gemini command-line tool
+- Any other MCP-compatible client
+
+**Cannot run standalone** - The server must be connected through an MCP client.
+
 ## Quick Start
 
 ### Option 1: Try it Now (Cloud)
@@ -80,7 +94,7 @@ claude mcp add math uvx math-mcp-learning-server
 - **Function Plotting**: Generate mathematical function plots with base64-encoded PNG output
 - **Statistical Histograms**: Visualize data distributions with mean and median indicators
 - **Cloud Deployment**: Visualization tools (matplotlib) are included in the cloud deployment
-- **Local Development**: Install with `pip install math-mcp-learning-server[plotting]` for local development
+- **Local Development**: Install with `uv pip install math-mcp-learning-server[plotting]` for local development
 
 ### Enterprise-Grade Quality
 - **Security Logging**: Monitor and log potentially dangerous expression attempts
@@ -162,8 +176,9 @@ uv run mypy src/
 # Run linting
 uv run ruff check
 
-# Start the MCP server
-uv run math-mcp-learning-server
+# Test the MCP server with FastMCP dev mode
+uv run fastmcp dev src/math_mcp/server.py
+# Then connect via MCP client (Claude Desktop, Claude Code, etc.)
 ```
 
 ### Adding New Tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.6.4"
+version = "0.6.5"
 description = "Production-ready educational MCP server with persistent workspace and FastMCP Cloud support - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Clarify MCP Client Requirements

This release improves documentation clarity about MCP client requirements and standardizes on `uv` for all installation commands.

### Key Changes

**README.md:**
- Added **Requirements section** explicitly stating this is an MCP server
- Listed supported MCP clients: Claude Desktop/Code, OpenCode, AmazonQ, Codex CLI, Gemini CLI, etc.
- Stated clearly: **Cannot run standalone** - must use MCP client
- Fixed development section: `uv run fastmcp dev` instead of suggesting standalone usage
- Replaced `pip install` with `uv pip install` throughout

**FUTURE_IMPROVEMENTS.md:**
- Added **MCP Client Requirement section** at the top
- Updated "User Experience" examples to mention MCP client context
- Replaced all `pip install` commands with `uv pip install`
- Added "Then connect via MCP client" reminders to installation blocks
- Updated error messages to use `uv pip install`

**pyproject.toml:**
- Version bumped to 0.6.5

### Why This Release?

**Issue identified:** Documentation didn't clearly state that:
1. An MCP client is **required** to use the server
2. The server **cannot run standalone**
3. What MCP clients are supported

**Also:** User prefers `uv` for safety and better dependency management - standardized all install commands.

### Testing

✅ All 53 tests pass (1.43s)  
✅ No code changes - documentation only

### Impact

Better onboarding for new users:
- Clear expectations about MCP client requirement
- Comprehensive list of supported clients
- Consistent installation commands using modern `uv` tooling