### PR TITLE
fix: Use absolute import for FastMCP Cloud compatibility

### DIFF
--- a/src/math_mcp/server.py
+++ b/src/math_mcp/server.py
@@ -16,8 +16,8 @@ from typing import Any
 from pydantic import BaseModel, Field
 from fastmcp import FastMCP, Context
 
-# Import visualization functions
-from . import visualization
+# Import visualization functions (using absolute import for FastMCP Cloud compatibility)
+from math_mcp import visualization
 
 
 # === PYDANTIC MODELS FOR STRUCTURED OUTPUT ===


### PR DESCRIPTION
## Issue

v0.7.0 deployment failed on FastMCP Cloud with error:
```
Failed to run: attempted relative import with no known parent package
```

## Root Cause

Line 20 in `server.py` used relative import:
```python
from . import visualization
```

FastMCP Cloud loads `server.py` directly without package context, causing relative imports to fail.

## Solution

Changed to absolute import:
```python
from math_mcp import visualization
```

This works in both:
- Package usage (tests, local development)
- Direct execution (FastMCP Cloud deployment)

## Testing

- ✅ All 67 tests passing
- ✅ Type checking clean (mypy)
- ✅ Linting clean (ruff)
- ✅ Import tested locally

## Impact

Hotfix for v0.7.0 cloud deployment failure. No breaking changes.